### PR TITLE
Clarify docstring for num_items parameter of DeviceSegmentedRadixSort

### DIFF
--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -182,7 +182,10 @@ struct DeviceSegmentedRadixSort
    *   sequence of associated value items
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -408,7 +411,10 @@ struct DeviceSegmentedRadixSort
    *   to the sorted output values
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -615,7 +621,10 @@ struct DeviceSegmentedRadixSort
    *   sequence of associated value items
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -843,7 +852,10 @@ struct DeviceSegmentedRadixSort
    *   to the sorted output values
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -1040,7 +1052,10 @@ struct DeviceSegmentedRadixSort
    *   Device-accessible pointer to the sorted output sequence of key data
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1240,7 +1255,10 @@ struct DeviceSegmentedRadixSort
    *   point to the sorted output keys
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1431,7 +1449,10 @@ struct DeviceSegmentedRadixSort
    *   Device-accessible pointer to the sorted output sequence of key data
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1630,7 +1651,10 @@ struct DeviceSegmentedRadixSort
    *   point to the sorted output keys
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments)
+   *   The total number of items to sort (across all segments). If segments
+   *   are non-contiguous, this should include unused items in between
+   *   segments, namely all items between the start of the first and end
+   *   of the last segment.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data


### PR DESCRIPTION
In the case where the user specifies non-contiguous segments (segments which do not cover the entirety of `d_keys_in`), the `num_items` parameter must include non-covered items. It should be the length of the total range to sort, from the start of the first segment to the end of the last, inclusive of any unused elements.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
